### PR TITLE
chore: fdb v0.2.0 release

### DIFF
--- a/fdb-gen/Cargo.toml
+++ b/fdb-gen/Cargo.toml
@@ -1,12 +1,18 @@
 [package]
 name = "fdb-gen"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 authors = ["fdb-rs Developers"]
 description = """
 Binding generation helper for FoundationDB
 """
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/fdb-rs/fdb"
+keywords = ["foundationdb", "tokio"]
+categories = ["database", "external-ffi-bindings"]
+
+[package.metadata.docs.rs]
+features = ["fdb-6_3"]
 
 [features]
 default = []

--- a/fdb-sys/Cargo.toml
+++ b/fdb-sys/Cargo.toml
@@ -1,12 +1,18 @@
 [package]
 name = "fdb-sys"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 authors = ["fdb-rs Developers"]
 description = """
 Binding to the C APIs for FoundationDB
 """
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/fdb-rs/fdb"
+keywords = ["foundationdb", "tokio"]
+categories = ["database", "external-ffi-bindings"]
+
+[package.metadata.docs.rs]
+features = ["fdb-6_3"]
 
 [features]
 default = []

--- a/fdb/Cargo.toml
+++ b/fdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdb"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 authors = ["fdb-rs Developers"]
 
@@ -8,6 +8,12 @@ description = """
 FoundationDB Client API for Tokio
 """
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/fdb-rs/fdb"
+keywords = ["foundationdb", "tokio"]
+categories = ["api-bindings", "database"]
+
+[package.metadata.docs.rs]
+features = ["fdb-6_3"]
 
 [features]
 default = []
@@ -15,7 +21,7 @@ fdb-6_3 = ["fdb-gen/fdb-6_3", "fdb-sys/fdb-6_3"]
 
 [dependencies]
 bytes = "1"
-fdb-sys = { version = "0.1.0", path = "../fdb-sys", default-features = false }
+fdb-sys = { version = "0.2.0", path = "../fdb-sys", default-features = false }
 futures = "0.3"
 nom = "7"
 num-bigint = "0.4"
@@ -30,4 +36,4 @@ impls = "1"
 libc = "0.2"
 
 [build-dependencies]
-fdb-gen = { version = "0.1.0", path = "../fdb-gen", default-features = false }
+fdb-gen = { version = "0.2.0", path = "../fdb-gen", default-features = false }


### PR DESCRIPTION
This is the first release of FoundationDB Client API for Tokio.