### PR TITLE
chore: remove patch version

### DIFF
--- a/fdb-gen/Cargo.toml
+++ b/fdb-gen/Cargo.toml
@@ -20,4 +20,4 @@ default = []
 fdb-6_3 = []
 
 [dependencies]
-xml-rs = "0.8.3"
+xml-rs = "0.8"

--- a/fdb-sys/Cargo.toml
+++ b/fdb-sys/Cargo.toml
@@ -22,4 +22,4 @@ fdb-6_3 = []
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.59.0"
+bindgen = "0.59"


### PR DESCRIPTION
There is no need to have patch version in `dependencies` and
`build-dependencies`.