### PR TITLE
feat: introduce new methods for `KeyValue`

### DIFF
--- a/fdb-stacktester/fdb-stacktester-630/src/main.rs
+++ b/fdb-stacktester/fdb-stacktester-630/src/main.rs
@@ -288,7 +288,7 @@ impl StackMachine {
         );
 
         for (inst_number, kv) in kvs.into_iter().enumerate() {
-            let inst = Tuple::from_bytes(kv.get_value().clone()).unwrap_or_else(|err| {
+            let inst = Tuple::from_bytes(kv.into_value()).unwrap_or_else(|err| {
                 panic!("Error occurred during `Tuple::from_bytes`: {:?}", err)
             });
             sm.process_inst(inst_number, inst).await;
@@ -2001,16 +2001,17 @@ impl StackMachine {
         let mut tup = Tuple::new();
 
         for kv in kvs {
+            let (key, value) = kv.into_parts();
             match prefix_filter {
                 Some(ref p) => {
-                    if key_util::starts_with(kv.get_key().clone(), p.clone()) {
-                        tup.add_bytes(kv.get_key().clone().into());
-                        tup.add_bytes(kv.get_value().clone().into());
+                    if key_util::starts_with(key.clone(), p.clone()) {
+                        tup.add_bytes(key.into());
+                        tup.add_bytes(value.into());
                     }
                 }
                 None => {
-                    tup.add_bytes(kv.get_key().clone().into());
-                    tup.add_bytes(kv.get_value().clone().into());
+                    tup.add_bytes(key.into());
+                    tup.add_bytes(value.into());
                 }
             }
         }

--- a/fdb/examples/get_range.rs
+++ b/fdb/examples/get_range.rs
@@ -58,11 +58,11 @@ fn main() -> Result<(), Box<dyn Error>> {
                 );
 
                 while let Some(x) = range_stream.next().await {
-                    let kv = x?;
+                    let (key, value) = x?.into_parts();
                     println!(
                         "{} is {}",
-                        String::from_utf8_lossy(&Bytes::from(kv.get_key().clone())[..]),
-                        String::from_utf8_lossy(&Bytes::from(kv.get_value().clone())[..])
+                        String::from_utf8_lossy(&Bytes::from(key)[..]),
+                        String::from_utf8_lossy(&Bytes::from(value)[..])
                     );
                 }
 
@@ -72,11 +72,11 @@ fn main() -> Result<(), Box<dyn Error>> {
                     .into_stream(&tr, RangeOptions::default());
 
                 while let Some(x) = range_stream.next().await {
-                    let kv = x?;
+                    let (key, value) = x?.into_parts();
                     println!(
                         "{} is {}",
-                        String::from_utf8_lossy(&Bytes::from(kv.get_key().clone())[..]),
-                        String::from_utf8_lossy(&Bytes::from(kv.get_value().clone())[..])
+                        String::from_utf8_lossy(&Bytes::from(key)[..]),
+                        String::from_utf8_lossy(&Bytes::from(value)[..])
                     );
                 }
 
@@ -96,11 +96,11 @@ fn main() -> Result<(), Box<dyn Error>> {
                 );
 
                 while let Some(x) = range_stream.next().await {
-                    let kv = x?;
+                    let (key, value) = x?.into_parts();
                     println!(
                         "{} is {}",
-                        String::from_utf8_lossy(&Bytes::from(kv.get_key().clone())[..]),
-                        String::from_utf8_lossy(&Bytes::from(kv.get_value().clone())[..])
+                        String::from_utf8_lossy(&Bytes::from(key)[..]),
+                        String::from_utf8_lossy(&Bytes::from(value)[..])
                     );
                 }
 
@@ -110,11 +110,11 @@ fn main() -> Result<(), Box<dyn Error>> {
                     .into_stream(&tr, RangeOptions::default());
 
                 while let Some(x) = range_stream.next().await {
-                    let kv = x?;
+                    let (key, value) = x?.into_parts();
                     println!(
                         "{} is {}",
-                        String::from_utf8_lossy(&Bytes::from(kv.get_key().clone())[..]),
-                        String::from_utf8_lossy(&Bytes::from(kv.get_value().clone())[..])
+                        String::from_utf8_lossy(&Bytes::from(key)[..]),
+                        String::from_utf8_lossy(&Bytes::from(value)[..])
                     );
                 }
 

--- a/fdb/src/database/fdb_database.rs
+++ b/fdb/src/database/fdb_database.rs
@@ -131,7 +131,7 @@ impl FdbDatabase {
             res.push({
                 // `13` because that is the length of
                 // `"\xFF/keyServers/"`.
-                Into::<Key>::into(Into::<Bytes>::into(kv.get_key().clone()).slice(13..))
+                Into::<Key>::into(Into::<Bytes>::into(kv.into_key()).slice(13..))
             });
         }
 

--- a/fdb/src/key_value.rs
+++ b/fdb/src/key_value.rs
@@ -49,14 +49,29 @@ pub struct KeyValue {
 }
 
 impl KeyValue {
-    /// Gets the key from [`KeyValue`].
-    pub fn get_key(&self) -> &Key {
+    /// Gets a reference to [`Key`] from [`KeyValue`].
+    pub fn get_key_ref(&self) -> &Key {
         &self.key
     }
 
-    /// Gets the value from [`KeyValue`].
-    pub fn get_value(&self) -> &Value {
+    /// Gets a reference to [`Value`] from [`KeyValue`].
+    pub fn get_value_ref(&self) -> &Value {
         &self.value
+    }
+
+    /// Extract [`Key`] from [`KeyValue`].
+    pub fn into_key(self) -> Key {
+        self.key
+    }
+
+    /// Extract [`Value`] from [`KeyValue`].
+    pub fn into_value(self) -> Value {
+        self.value
+    }
+
+    /// Extract [`Key`] and [`Value`] from [`KeyValue`].
+    pub fn into_parts(self) -> (Key, Value) {
+        (self.key, self.value)
     }
 
     pub(crate) fn new(key: Key, value: Value) -> KeyValue {

--- a/fdb/src/range.rs
+++ b/fdb/src/range.rs
@@ -476,11 +476,12 @@ impl RangeResultStateMachine {
 
                         if self.reverse {
                             self.end_sel = KeySelector::first_greater_or_equal(
-                                kvs[last_index].get_key().clone(),
+                                kvs[last_index].get_key_ref().clone(),
                             );
                         } else {
-                            self.begin_sel =
-                                KeySelector::first_greater_than(kvs[last_index].get_key().clone());
+                            self.begin_sel = KeySelector::first_greater_than(
+                                kvs[last_index].get_key_ref().clone(),
+                            );
                         }
                     }
 

--- a/fdb/src/tuple/versionstamp.rs
+++ b/fdb/src/tuple/versionstamp.rs
@@ -82,18 +82,13 @@ const VERSIONSTAMP_USER_VERSION_LEN: usize = 2;
 ///
 ///         let subspace_range = subspace.range(&Tuple::new());
 ///
-///         let key = tr
-///             .get_range(
-///                 KeySelector::first_greater_or_equal(subspace_range.begin().clone()),
-///                 KeySelector::first_greater_or_equal(subspace_range.end().clone()),
-///                 RangeOptions::default(),
-///             )
+///         let key = subspace_range
+///             .into_stream(&tr, RangeOptions::default())
 ///             .take(1)
 ///             .next()
 ///             .await
 ///             .unwrap()?
-///             .get_key()
-///             .clone();
+///             .into_key();
 ///
 ///         Ok(subspace
 ///             .unpack(&key.into())?


### PR DESCRIPTION
Introduce new methods for `KeyValue` type. Also rename
`get_{key,value}` methods to `get_{key,value}_ref`.

Refs: #12