### PR TITLE
chore: fix `package.meta.docs.rs` for `fdb` crate

### DIFF
--- a/fdb/Cargo.toml
+++ b/fdb/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["foundationdb", "tokio"]
 categories = ["api-bindings", "database"]
 
 [package.metadata.docs.rs]
-features = ["fdb-6_3"]
+features = ["fdb-7_1"]
 
 [features]
 default = []


### PR DESCRIPTION
`fdb` crate's `package.meta.docs.rs` should use `fdb-7_1` for
`features` so that experimental features documentation shows up on
`docs.rs`.