### PR TITLE
chore: bump main to v0.4.0

### DIFF
--- a/fdb-gen/Cargo.toml
+++ b/fdb-gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdb-gen"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2018"
 rust-version = "1.49"
 authors = ["fdb-rs Developers"]

--- a/fdb-sys/Cargo.toml
+++ b/fdb-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdb-sys"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2018"
 rust-version = "1.49"
 authors = ["fdb-rs Developers"]

--- a/fdb/Cargo.toml
+++ b/fdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdb"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2018"
 rust-version = "1.49"
 authors = ["fdb-rs Developers"]
@@ -23,7 +23,7 @@ fdb-7_1 = ["fdb-gen/fdb-7_1", "fdb-sys/fdb-7_1"]
 
 [dependencies]
 bytes = "1"
-fdb-sys = { version = "0.3.0", path = "../fdb-sys", default-features = false }
+fdb-sys = { version = "0.4.0", path = "../fdb-sys", default-features = false }
 futures = "0.3"
 nom = "7"
 num-bigint = "0.4"
@@ -38,4 +38,4 @@ impls = "1"
 libc = "0.2"
 
 [build-dependencies]
-fdb-gen = { version = "0.3.0", path = "../fdb-gen", default-features = false }
+fdb-gen = { version = "0.4.0", path = "../fdb-gen", default-features = false }


### PR DESCRIPTION
`main` branch now tracks next release