### PR TITLE
ci: update container image

### DIFF
--- a/.github/workflows/pull_request-6_3_24.yml
+++ b/.github/workflows/pull_request-6_3_24.yml
@@ -2,7 +2,7 @@ name: pull_request-6_3_24
 
 env:
   image_version: 6_3_24
-  image_tag: 3faa15b369a0
+  image_tag: a941c67da0e8
 
 on:
   pull_request:

--- a/.github/workflows/pull_request-7_1_12.yml
+++ b/.github/workflows/pull_request-7_1_12.yml
@@ -1,8 +1,8 @@
-name: pull_request-7_1_3
+name: pull_request-7_1_12
 
 env:
-  image_version: 7_1_3
-  image_tag: 3205cb0f188a
+  image_version: 7_1_12
+  image_tag: c72739bee1a9
 
 on:
   pull_request:
@@ -25,11 +25,11 @@ jobs:
       -
         name: Run 7.1/pull_request.sh
         run: |
-          sudo podman exec --user runner:docker --workdir /home/runner/fdb/nix/ci --tty fdb nix develop .#pull_request-7_1_3 --command ./7.1/pull_request.sh
+          sudo podman exec --user runner:docker --workdir /home/runner/fdb/nix/ci --tty fdb nix develop .#pull_request-7_1_12 --command ./7.1/pull_request.sh
       -
         name: Run 7.1/pull_request_lcov.sh
         run: |
-          sudo podman exec --user runner:docker --workdir /home/runner/fdb/nix/ci --tty fdb nix develop .#pull_request-nightly-7_1_3 --command ./7.1/pull_request_lcov.sh
+          sudo podman exec --user runner:docker --workdir /home/runner/fdb/nix/ci --tty fdb nix develop .#pull_request-nightly-7_1_12 --command ./7.1/pull_request_lcov.sh
       -
         name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/push-6_3_24.yml
+++ b/.github/workflows/push-6_3_24.yml
@@ -2,7 +2,7 @@ name: push-6_3_24
 
 env:
   image_version: 6_3_24
-  image_tag: 3faa15b369a0
+  image_tag: a941c67da0e8
 
 on:
   push:

--- a/.github/workflows/push-7_1_12.yml
+++ b/.github/workflows/push-7_1_12.yml
@@ -1,8 +1,8 @@
-name: push-7_1_3
+name: push-7_1_12
 
 env:
-  image_version: 7_1_3
-  image_tag: 3205cb0f188a
+  image_version: 7_1_12
+  image_tag: c72739bee1a9
 
 on:
   push:
@@ -25,11 +25,11 @@ jobs:
       -
         name: Run 7.1/push.sh
         run: |
-          sudo podman exec --user runner:docker --workdir /home/runner/fdb/nix/ci --tty fdb nix develop .#push-7_1_3 --command ./7.1/push.sh
+          sudo podman exec --user runner:docker --workdir /home/runner/fdb/nix/ci --tty fdb nix develop .#push-7_1_12 --command ./7.1/push.sh
       -
         name: Run 7.1/push_lcov.sh
         run: |
-          sudo podman exec --user runner:docker --workdir /home/runner/fdb/nix/ci --tty fdb nix develop .#push-nightly-7_1_3 --command ./7.1/push_lcov.sh
+          sudo podman exec --user runner:docker --workdir /home/runner/fdb/nix/ci --tty fdb nix develop .#push-nightly-7_1_12 --command ./7.1/push_lcov.sh
       -
         name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/push-rustdoc-7_1_12.yml
+++ b/.github/workflows/push-rustdoc-7_1_12.yml
@@ -1,8 +1,8 @@
-name: push-rustdoc-7_1_3
+name: push-rustdoc-7_1_12
 
 env:
-  image_version: 7_1_3
-  image_tag: 3205cb0f188a
+  image_version: 7_1_12
+  image_tag: c72739bee1a9
 
 on:
   push:
@@ -25,7 +25,7 @@ jobs:
       -
         name: Run 7.1/push_rustdoc.sh
         run: |
-          sudo podman exec --user runner:docker --workdir /home/runner/fdb/nix/ci --tty fdb nix develop .#push_rustdoc-7_1_3 --command ./7.1/push_rustdoc.sh
+          sudo podman exec --user runner:docker --workdir /home/runner/fdb/nix/ci --tty fdb nix develop .#push_rustdoc-7_1_12 --command ./7.1/push_rustdoc.sh
       -
         name: Deploy docs
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/schedule-6_3_24.yml
+++ b/.github/workflows/schedule-6_3_24.yml
@@ -2,7 +2,7 @@ name: schedule-6_3_24
 
 env:
   image_version: 6_3_24
-  image_tag: 3faa15b369a0
+  image_tag: a941c67da0e8
 
 # We adjust the number of iterations in `schedule.sh` so that the job
 # takes approximately 1 hour to finish. Jobs are scheduled at minute

--- a/.github/workflows/schedule-7_1_12.yml
+++ b/.github/workflows/schedule-7_1_12.yml
@@ -1,8 +1,8 @@
-name: schedule-7_1_3
+name: schedule-7_1_12
 
 env:
-  image_version: 7_1_3
-  image_tag: 3205cb0f188a
+  image_version: 7_1_12
+  image_tag: c72739bee1a9
 
 # We adjust the number of iterations in `schedule.sh` so that the job
 # takes approximately 1 hour to finish. Jobs are scheduled at minute
@@ -28,7 +28,7 @@ jobs:
       -
         name: Run 7.1/schedule.sh
         run: |
-          sudo podman exec --user runner:docker --workdir /home/runner/fdb/nix/ci --tty fdb nix develop .#schedule-7_1_3 --command ./7.1/schedule.sh
+          sudo podman exec --user runner:docker --workdir /home/runner/fdb/nix/ci --tty fdb nix develop .#schedule-7_1_12 --command ./7.1/schedule.sh
       -
         name: Stop container
         run: |

--- a/fdb-stacktester/fdb-stacktester-630/src/main.rs
+++ b/fdb-stacktester/fdb-stacktester-630/src/main.rs
@@ -953,7 +953,7 @@ impl StackMachine {
                     for ti in 0..packed_tuple.size() {
                         let mut res = Tuple::new();
 
-                        let _ = packed_tuple
+                        packed_tuple
                             .get_bigint(ti)
                             .map(|bi| res.add_bigint(bi))
                             .or_else(|_| packed_tuple.get_bool(ti).map(|b| res.add_bool(b)))
@@ -2328,7 +2328,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
         // Ensure that start thread task successfully exits. This
         // happens when there are no more active threads.
-        let _ = start_thread_task_join_handle.await?;
+        start_thread_task_join_handle.await?;
 
         Result::<(), Box<dyn Error>>::Ok(())
     })?;

--- a/fdb-stacktester/fdb-stacktester-710/src/main.rs
+++ b/fdb-stacktester/fdb-stacktester-710/src/main.rs
@@ -1034,7 +1034,7 @@ impl StackMachine {
                     for ti in 0..packed_tuple.size() {
                         let mut res = Tuple::new();
 
-                        let _ = packed_tuple
+                        packed_tuple
                             .get_bigint(ti)
                             .map(|bi| res.add_bigint(bi))
                             .or_else(|_| packed_tuple.get_bool(ti).map(|b| res.add_bool(b)))
@@ -2177,7 +2177,7 @@ impl StackMachine {
                 }
                 Err(err) => self.push_err(inst_number, err),
             }
-        } else if let Err(err) = unsafe { tr.run(f).await } {
+        } else if let Err(err) = tr.run(f).await {
             self.push_err(inst_number, err);
         }
     }
@@ -2518,7 +2518,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
         // Ensure that start thread task successfully exits. This
         // happens when there are no more active threads.
-        let _ = start_thread_task_join_handle.await?;
+        start_thread_task_join_handle.await?;
 
         Result::<(), Box<dyn Error>>::Ok(())
     })?;

--- a/fdb/examples/get_mapped_range.rs
+++ b/fdb/examples/get_mapped_range.rs
@@ -230,7 +230,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         // Records with primary key of 0..=4 will be inserted.
         insert_record_with_indexes(5, &fdb_database).await?;
 
-        let _ = fdb_database
+        fdb_database
             .run(|tr| async move {
                 // Get mapped key values from 1..=3.
                 let mut mapped_range_stream = Range::new(index_entry_key(1), index_entry_key(4))

--- a/nix/ci/7.1/pull_request.sh
+++ b/nix/ci/7.1/pull_request.sh
@@ -68,7 +68,7 @@ cd fdb-stacktester/fdb-stacktester-710 || { echo "cd failure"; exit 1; }
 
 cargo build --bin fdb-stacktester-710 --release
 
-pip install foundationdb==7.1.3
+pip install foundationdb==7.1.12
 
 # Run `scripted` test once. This is similar to how it is done in
 # `run_tester_loop.sh`.

--- a/nix/ci/7.1/pull_request_lcov.sh
+++ b/nix/ci/7.1/pull_request_lcov.sh
@@ -20,7 +20,7 @@ cargo llvm-cov --lib --tests --features=fdb-7_1 --lcov --output-path lcov/tests.
 
 # Run examples
 
-/opt/fdb/cli/7.1.3/fdbcli -C /home/runner/fdb.cluster --exec "writemode on; clearrange \x00 \xff"
+/opt/fdb/cli/7.1.12/fdbcli -C /home/runner/fdb.cluster --exec "writemode on; clearrange \x00 \xff"
 
 cargo llvm-cov run --example get_committed_version --features=fdb-7_1 --lcov --output-path lcov/get_committed_version.info
 
@@ -29,27 +29,27 @@ cargo llvm-cov run --example get_committed_version --features=fdb-7_1 --lcov --o
 # #
 # # [1] https://forums.foundationdb.org/t/everything-about-getmappedrange/3280/3
 
-# /opt/fdb/cli/7.1.3/fdbcli -C /home/runner/fdb.cluster --exec "writemode on; clearrange \x00 \xff"
+# /opt/fdb/cli/7.1.12/fdbcli -C /home/runner/fdb.cluster --exec "writemode on; clearrange \x00 \xff"
 
 # cargo llvm-cov run --example get_mapped_range --features=fdb-7_1 --lcov --output-path lcov/get_mapped_range.info
 
-/opt/fdb/cli/7.1.3/fdbcli -C /home/runner/fdb.cluster --exec "writemode on; clearrange \x00 \xff"
+/opt/fdb/cli/7.1.12/fdbcli -C /home/runner/fdb.cluster --exec "writemode on; clearrange \x00 \xff"
 
 cargo llvm-cov run --example get_range --features=fdb-7_1 --lcov --output-path lcov/get_range.info
 
-/opt/fdb/cli/7.1.3/fdbcli -C /home/runner/fdb.cluster --exec "writemode on; clearrange \x00 \xff"
+/opt/fdb/cli/7.1.12/fdbcli -C /home/runner/fdb.cluster --exec "writemode on; clearrange \x00 \xff"
 
 cargo llvm-cov run --example get_versionstamp --features=fdb-7_1 --lcov --output-path lcov/get_versionstamp.info
 
-/opt/fdb/cli/7.1.3/fdbcli -C /home/runner/fdb.cluster --exec "writemode on; clearrange \x00 \xff"
+/opt/fdb/cli/7.1.12/fdbcli -C /home/runner/fdb.cluster --exec "writemode on; clearrange \x00 \xff"
 
 cargo llvm-cov run --example hello_world --features=fdb-7_1 --lcov --output-path lcov/hello_world.info
 
-/opt/fdb/cli/7.1.3/fdbcli -C /home/runner/fdb.cluster --exec "writemode on; clearrange \x00 \xff"
+/opt/fdb/cli/7.1.12/fdbcli -C /home/runner/fdb.cluster --exec "writemode on; clearrange \x00 \xff"
 
 cargo llvm-cov run --example open_database --features=fdb-7_1 --lcov --output-path lcov/open_database.info
 
-/opt/fdb/cli/7.1.3/fdbcli -C /home/runner/fdb.cluster --exec "writemode on; clearrange \x00 \xff"
+/opt/fdb/cli/7.1.12/fdbcli -C /home/runner/fdb.cluster --exec "writemode on; clearrange \x00 \xff"
 
 cargo llvm-cov run --example watch --features=fdb-7_1 --lcov --output-path lcov/watch.info
 

--- a/nix/ci/7.1/push.sh
+++ b/nix/ci/7.1/push.sh
@@ -68,7 +68,7 @@ cd fdb-stacktester/fdb-stacktester-710 || { echo "cd failure"; exit 1; }
 
 cargo build --bin fdb-stacktester-710 --release
 
-pip install foundationdb==7.1.3
+pip install foundationdb==7.1.12
 
 # Run `scripted` test once. This is similar to how it is done in
 # `run_tester_loop.sh`.

--- a/nix/ci/7.1/push_lcov.sh
+++ b/nix/ci/7.1/push_lcov.sh
@@ -20,7 +20,7 @@ cargo llvm-cov --lib --tests --features=fdb-7_1 --lcov --output-path lcov/tests.
 
 # Run examples
 
-/opt/fdb/cli/7.1.3/fdbcli -C /home/runner/fdb.cluster --exec "writemode on; clearrange \x00 \xff"
+/opt/fdb/cli/7.1.12/fdbcli -C /home/runner/fdb.cluster --exec "writemode on; clearrange \x00 \xff"
 
 cargo llvm-cov run --example get_committed_version --features=fdb-7_1 --lcov --output-path lcov/get_committed_version.info
 
@@ -29,27 +29,27 @@ cargo llvm-cov run --example get_committed_version --features=fdb-7_1 --lcov --o
 # #
 # # [1] https://forums.foundationdb.org/t/everything-about-getmappedrange/3280/3
 
-# /opt/fdb/cli/7.1.3/fdbcli -C /home/runner/fdb.cluster --exec "writemode on; clearrange \x00 \xff"
+# /opt/fdb/cli/7.1.12/fdbcli -C /home/runner/fdb.cluster --exec "writemode on; clearrange \x00 \xff"
 
 # cargo llvm-cov run --example get_mapped_range --features=fdb-7_1 --lcov --output-path lcov/get_mapped_range.info
 
-/opt/fdb/cli/7.1.3/fdbcli -C /home/runner/fdb.cluster --exec "writemode on; clearrange \x00 \xff"
+/opt/fdb/cli/7.1.12/fdbcli -C /home/runner/fdb.cluster --exec "writemode on; clearrange \x00 \xff"
 
 cargo llvm-cov run --example get_range --features=fdb-7_1 --lcov --output-path lcov/get_range.info
 
-/opt/fdb/cli/7.1.3/fdbcli -C /home/runner/fdb.cluster --exec "writemode on; clearrange \x00 \xff"
+/opt/fdb/cli/7.1.12/fdbcli -C /home/runner/fdb.cluster --exec "writemode on; clearrange \x00 \xff"
 
 cargo llvm-cov run --example get_versionstamp --features=fdb-7_1 --lcov --output-path lcov/get_versionstamp.info
 
-/opt/fdb/cli/7.1.3/fdbcli -C /home/runner/fdb.cluster --exec "writemode on; clearrange \x00 \xff"
+/opt/fdb/cli/7.1.12/fdbcli -C /home/runner/fdb.cluster --exec "writemode on; clearrange \x00 \xff"
 
 cargo llvm-cov run --example hello_world --features=fdb-7_1 --lcov --output-path lcov/hello_world.info
 
-/opt/fdb/cli/7.1.3/fdbcli -C /home/runner/fdb.cluster --exec "writemode on; clearrange \x00 \xff"
+/opt/fdb/cli/7.1.12/fdbcli -C /home/runner/fdb.cluster --exec "writemode on; clearrange \x00 \xff"
 
 cargo llvm-cov run --example open_database --features=fdb-7_1 --lcov --output-path lcov/open_database.info
 
-/opt/fdb/cli/7.1.3/fdbcli -C /home/runner/fdb.cluster --exec "writemode on; clearrange \x00 \xff"
+/opt/fdb/cli/7.1.12/fdbcli -C /home/runner/fdb.cluster --exec "writemode on; clearrange \x00 \xff"
 
 cargo llvm-cov run --example watch --features=fdb-7_1 --lcov --output-path lcov/watch.info
 

--- a/nix/ci/7.1/schedule.sh
+++ b/nix/ci/7.1/schedule.sh
@@ -15,7 +15,7 @@ cd ../../fdb-stacktester/fdb-stacktester-710 || { echo "cd failure"; exit 1; }
 
 cargo build --bin fdb-stacktester-710 --release
 
-pip install foundationdb==7.1.3
+pip install foundationdb==7.1.12
 
 # Run `scripted` test once. This is similar to how it is done in
 # `run_tester_loop.sh`.

--- a/nix/ci/cargo-llvm-cov/default.nix
+++ b/nix/ci/cargo-llvm-cov/default.nix
@@ -6,11 +6,11 @@
 stdenv.mkDerivation rec {
   pname = "cargo-llvm-cov";
 
-  version = "0.3.1";
+  version = "0.4.9";
 
   src = fetchurl {
     url = "https://github.com/taiki-e/cargo-llvm-cov/releases/download/v${version}/cargo-llvm-cov-x86_64-unknown-linux-gnu.tar.gz";
-    sha256 = "sha256-IeAHM2le6cjGbU13Jk4OkuCDDZ7wPxmjIZh5ko7vlis=";
+    sha256 = "sha256-Gg24R33D1IrG0jX35FyD4sz5vJlpEyrY7Zzo9FKEW+A=";
   };
 
   unpackPhase = ":";

--- a/nix/ci/fdb-7.1/default.nix
+++ b/nix/ci/fdb-7.1/default.nix
@@ -34,8 +34,8 @@ in
 [
   (
     let
-      version = "7.1.3";
-      sha256 = "sha256-kXCqh5vinx7EwpWKEvQ77lmy1OVODcOd23GPD/RY2jk=";
+      version = "7.1.12";
+      sha256 = "sha256-5KeYLcy22eYWuQVUMIlrAP90h0crAzvkrcl/ADZ5yCE=";
       isDir = false;
 
       fdb-client-lib = pkgs.callPackage ./client-lib { inherit version sha256 isDir; };
@@ -45,8 +45,8 @@ in
 
   (
     let
-      version = "7.1.3";
-      sha256 = "sha256-kXCqh5vinx7EwpWKEvQ77lmy1OVODcOd23GPD/RY2jk=";
+      version = "7.1.12";
+      sha256 = "sha256-5KeYLcy22eYWuQVUMIlrAP90h0crAzvkrcl/ADZ5yCE=";
       isDir = true;
 
       fdb-client-lib-dir = pkgs.callPackage ./client-lib { inherit version sha256 isDir; };
@@ -57,8 +57,8 @@ in
   (
     let
       name = "monitor";
-      sha256 = "sha256-67qgMHUa0giGs8KvahvKHtgk0ZQz7QpoDtiRPMM+JD8=";
-      version = "7.1.3";
+      version = "7.1.12";
+      sha256 = "sha256-meuNIjt6xhkuTM1AiF8fvtFM2SnM16MutNPsHH58gz8=";
 
       fdb-monitor = pkgs.callPackage ./app { inherit name sha256 version; };
     in
@@ -68,8 +68,8 @@ in
   (
     let
       name = "server";
-      sha256 = "sha256-SmlBVss1hPyr1NHIyW1ld6W6JCvVMsc6AWvYUydGUwA=";
-      version = "7.1.3";
+      version = "7.1.12";
+      sha256 = "sha256-FQzCcIAeFLfGszkJ61BJqYRlq2ev/fMxA93Lz6qkRJg=";
 
       fdb-server = pkgs.callPackage ./app { inherit name sha256 version; };
     in
@@ -79,8 +79,8 @@ in
   (
     let
       name = "cli";
-      sha256 = "sha256-6ZZvcZlRTC6yWZW3gbncChYzxC+iRHGCgLovIGeBcvo=";
-      version = "7.1.3";
+      version = "7.1.12";
+      sha256 = "sha256-JGHdRcAXii+hiOamrmy6GA5LG4a4aCfbF4o1LoHC4p0=";
 
       fdb-cli = pkgs.callPackage ./app { inherit name sha256 version; };
     in

--- a/nix/ci/flake.lock
+++ b/nix/ci/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1637014545,
-        "narHash": "sha256-26IZAc5yzlD9FlDT54io1oqG/bBoyka+FJk5guaX4x4=",
+        "lastModified": 1656065134,
+        "narHash": "sha256-oc6E6ByIw3oJaIyc67maaFcnjYOz1mMcOtHxbEf9NwQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "bba5dcc8e0b20ab664967ad83d24d64cb64ec4f4",
+        "rev": "bee6a7250dd1b01844a2de7e02e4df7d8a0a206c",
         "type": "github"
       },
       "original": {
@@ -17,26 +17,26 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1651571855,
-        "narHash": "sha256-KZie6c2J2DUPLjG2PkYSwGLvD6RygA3TxZSPQpctbNI=",
+        "lastModified": 1657654771,
+        "narHash": "sha256-uIGbt+rU89aTlSx8+4g9vKioWc8nmCCcaaFCNPHM07c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fd43ce017d4c95f47166d28664a004f57458a0b1",
+        "rev": "4aceab3cadf9fef6f70b9f6a9df964218650db0a",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-21.11",
+        "ref": "nixos-22.05",
         "type": "indirect"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1637453606,
-        "narHash": "sha256-Gy6cwUswft9xqsjWxFYEnx/63/qzaFUwatcbV5GF/GQ=",
+        "lastModified": 1656401090,
+        "narHash": "sha256-bUS2nfQsvTQW2z8SK7oEFSElbmoBahOPtbXPm0AL3I4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8afc4e543663ca0a6a4f496262cd05233737e732",
+        "rev": "16de63fcc54e88b9a106a603038dd5dd2feb21eb",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1651632340,
-        "narHash": "sha256-Kq1yghXZxJ12Sw1nbzoO2Ag8/AxqbbD84wiz8go159o=",
+        "lastModified": 1657767064,
+        "narHash": "sha256-Mp7LmSPnRfWqX7OElXr4HKNbTiDCXLaxijp23xQlDJk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "88991ffbd57e10b474ea768ec0b54c4f379c566c",
+        "rev": "db9443ca1384f94c0aa63f4e74115f7c0632a8e6",
         "type": "github"
       },
       "original": {

--- a/nix/ci/flake.nix
+++ b/nix/ci/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "CI Nix flakes";
 
-  inputs.nixpkgs.url = "nixpkgs/nixos-21.11";
+  inputs.nixpkgs.url = "nixpkgs/nixos-22.05";
 
   inputs.rust-overlay.url = "github:oxalica/rust-overlay";
 
@@ -88,6 +88,8 @@
 
           chown fdb:fdb /opt/fdb/data
           chown fdb:fdb /opt/fdb/log
+
+          mkdir -p /nix/var/nix/daemon-socket
 
           systemctl enable fdbcli.service
           systemctl enable foundationdb.service
@@ -232,7 +234,7 @@
         '';
       };
 
-    fdb-7_1_3 =
+    fdb-7_1_12 =
       let
         pkgs = import nixpkgs {
           system = "x86_64-linux";
@@ -252,13 +254,13 @@
 
         fdb = import ./fdb-7.1 { inherit pkgs; };
 
-        fdb-files = pkgs.callPackage ./fdb-files-7.1 { version = "7.1.3"; };
+        fdb-files = pkgs.callPackage ./fdb-files-7.1 { version = "7.1.12"; };
 
         fdb-systemd-units = builtins.attrValues fdb-files.systemd_units;
       in
       with pkgs;
       dockerTools.buildImageWithNixDb {
-        name = "fdb-7_1_3";
+        name = "fdb-7_1_12";
         tag = "latest";
 
         contents = [
@@ -315,6 +317,8 @@
           chown fdb:fdb /opt/fdb/data
           chown fdb:fdb /opt/fdb/log
 
+          mkdir -p /nix/var/nix/daemon-socket
+
           systemctl enable fdbcli.service
           systemctl enable foundationdb.service
           systemctl enable nix-daemon.socket
@@ -333,7 +337,7 @@
     # limitation around `+nightly`. `+nightly` is needed by
     # `cargo-llvm-cov`.
 
-    pull_request-7_1_3 =
+    pull_request-7_1_12 =
       let
         overlays = [ (import rust-overlay) ];
 
@@ -376,7 +380,7 @@
         '';
       };
 
-    pull_request-nightly-7_1_3 =
+    pull_request-nightly-7_1_12 =
       let
         overlays = [ (import rust-overlay) ];
 
@@ -397,7 +401,7 @@
           llvmPackages.libcxxClang
           openssl
           pkgconfig
-          (rust-bin.nightly."2022-05-04".default.override {
+          (rust-bin.nightly."2022-07-10".default.override {
             extensions = [
               "llvm-tools-preview"
             ];
@@ -413,7 +417,7 @@
         RUSTC_LINK_SEARCH_FDB_CLIENT_LIB = "/opt/fdb/client-lib";
       };
 
-    push-7_1_3 =
+    push-7_1_12 =
       let
         overlays = [ (import rust-overlay) ];
 
@@ -456,7 +460,7 @@
         '';
       };
 
-    push-nightly-7_1_3 =
+    push-nightly-7_1_12 =
       let
         overlays = [ (import rust-overlay) ];
 
@@ -493,7 +497,7 @@
         RUSTC_LINK_SEARCH_FDB_CLIENT_LIB = "/opt/fdb/client-lib";
       };
 
-    push_rustdoc-7_1_3 =
+    push_rustdoc-7_1_12 =
       let
         overlays = [ (import rust-overlay) ];
 
@@ -522,7 +526,7 @@
         RUSTC_LINK_SEARCH_FDB_CLIENT_LIB = "/opt/fdb/client-lib";
       };
 
-    schedule-7_1_3 =
+    schedule-7_1_12 =
       let
         overlays = [ (import rust-overlay) ];
 


### PR DESCRIPTION
Update container image to NixOS release 22.05.

Also update Rust to release 1.62 and FDB 7.1.x release to 7.1.12.

Adjust `fdb-stacktester-{630,710}` to Rust 1.62 clippy lints.

In NixOS 22.05 release, for some reason `/nix/var/nix/daemon-socket`
directory is not being created. So manually create this path so that
systemd's `nix-daemon.socket` can be properly started.

Update `cargo-llvm-cov` to 0.4.9 release.